### PR TITLE
Ignore vaults with base_id == ilk_id

### DIFF
--- a/src/bindings/mod.rs
+++ b/src/bindings/mod.rs
@@ -13,6 +13,6 @@ pub use imulticall2::ResultData as IMulticall2Result;
 pub use imulticall2::CallData as IMulticall2Call;
 
 pub type VaultIdType = [u8; 12];
-pub type ArtIdType = [u8; 6];
-pub type InkIdType = [u8; 6];
+pub type BaseIdType = [u8; 6];
+pub type IlkIdType = [u8; 6];
 pub type SeriesIdType = [u8; 6];


### PR DESCRIPTION
These vaults can be undercollaterized (after the series matures, debt starts to accumulate), but
they're never profitable to liquidate => we ignore them

Figuring out vault's base_id is a 2-step process (find series_id, look up the series), so we do
it outside of the regular multicall as an extra step (needs to be optimized later))