### PR TITLE
--target_collateral_offer: liquidate once this much collateral percentage is offered

### DIFF
--- a/contracts/FlashLiquidator.sol
+++ b/contracts/FlashLiquidator.sol
@@ -66,17 +66,6 @@ contract FlashLiquidator {
         return inkValue * 1e18 / accrued_debt;
     }
 
-    // @notice This is used by the bot to determine if the auction price has reached the final, minimum price yet
-    // @param  vaultId id of vault to check
-    // @return True if it has reached minimal price
-    function isAtMinimalPrice(bytes12 vaultId) public returns (bool) {
-        bytes6 ilkId = (cauldron.vaults(vaultId)).ilkId;
-        (uint32 duration, ) = witch.ilks(ilkId);
-        (, uint32 auctionStart) = witch.auctions(vaultId);
-        uint256 elapsed = uint32(block.timestamp) - auctionStart;
-        return elapsed >= duration;
-    }
-
     // @notice Returns the address of a valid Uniswap V3 Pool
     // @dev from 'uniswap/v3-periphery/contracts/libraries/CallbackValidation.sol'
     // @param poolKey The identifying key of the V3 pool

--- a/regression_tests/flashLiquidator.ts
+++ b/regression_tests/flashLiquidator.ts
@@ -223,31 +223,6 @@ describe("flash liquidator", function () {
         expect(new_vaults_message).to.be.equal("New vaults: 1086");
     });
 
-    it("does not liquidate before 90% collateral is released", async function () {
-        this.timeout(1800e3);
-
-        await fork(13911677)
-        const [_owner, liquidator] = await deploy_flash_liquidator();
-
-        const liquidator_logs = await run_liquidator(tmp_root, liquidator);
-
-        const vault_not_to_be_auctioned = "00cbb039b7b8103611a9717f";
-
-        let new_vaults_message;
-
-        for (const log_record of liquidator_logs) {
-            if (log_record["level"] == "INFO" && log_record["fields"]["message"] == "Submitted liquidation") {
-                const vault_id = log_record["fields"]["vault_id"];
-                expect(vault_id).to.not.equal(`"${vault_not_to_be_auctioned}"`);
-            }
-            if (log_record["fields"]["message"] && log_record["fields"]["message"].startsWith("New vaults: ")) {
-                new_vaults_message = log_record["fields"]["message"];
-            }
-        }
-        // to make sure the bot did something and did not just crash
-        expect(new_vaults_message).to.be.equal("New vaults: 1086");
-    });
-
     describe("90% collateral offer", function () {
         const test_vault_id = "3ddcb12f945cd58f4acf26c7";
         const auction_started_in_block = 13900229; // 1640781211 ~= 04:33:31

--- a/regression_tests/flashLiquidator.ts
+++ b/regression_tests/flashLiquidator.ts
@@ -222,4 +222,85 @@ describe("flash liquidator", function () {
         // to make sure the bot did something and did not just crash
         expect(new_vaults_message).to.be.equal("New vaults: 1086");
     });
+
+    it("does not liquidate before 90% collateral is released", async function () {
+        this.timeout(1800e3);
+
+        await fork(13911677)
+        const [_owner, liquidator] = await deploy_flash_liquidator();
+
+        const liquidator_logs = await run_liquidator(tmp_root, liquidator);
+
+        const vault_not_to_be_auctioned = "00cbb039b7b8103611a9717f";
+
+        let new_vaults_message;
+
+        for (const log_record of liquidator_logs) {
+            if (log_record["level"] == "INFO" && log_record["fields"]["message"] == "Submitted liquidation") {
+                const vault_id = log_record["fields"]["vault_id"];
+                expect(vault_id).to.not.equal(`"${vault_not_to_be_auctioned}"`);
+            }
+            if (log_record["fields"]["message"] && log_record["fields"]["message"].startsWith("New vaults: ")) {
+                new_vaults_message = log_record["fields"]["message"];
+            }
+        }
+        // to make sure the bot did something and did not just crash
+        expect(new_vaults_message).to.be.equal("New vaults: 1086");
+    });
+
+    describe("90% collateral offer", function () {
+        const test_vault_id = "3ddcb12f945cd58f4acf26c7";
+        const auction_started_in_block = 13900229; // 1640781211 ~= 04:33:31
+        const liquidated_in_block = 13900498; // 1640784847 ~= 05:34:07
+
+        const auction_start = 1640781211;
+        const ilk_id = "0x303300000000";
+        const duration = 3600;
+        const initial_offer = 666000; // .000000000000666000 really?
+
+        it("triggers liquidation upon expiry", async function () {
+            this.timeout(1800e3);
+
+            // block timestamp: 1640784562 ~= 05:29:22; ~95% collateral is offered
+            await fork(13900485);
+            const [_owner, liquidator] = await deploy_flash_liquidator();
+
+            const liquidator_logs = await run_liquidator(tmp_root, liquidator);
+
+            let vault_is_liquidated = false;
+            for (const log_record of liquidator_logs) {
+                if (log_record["level"] == "INFO" && log_record["fields"]["message"] == "Submitted buy order") {
+                    const vault_id = log_record["fields"]["vault_id"];
+                    if (vault_id == `"${test_vault_id}"`) {
+                        vault_is_liquidated = true;
+                    }
+                }
+            }
+            expect(vault_is_liquidated).to.equal(true);
+        })
+
+        it("does not trigger liquidation before expiry", async function () {
+            this.timeout(1800e3);
+
+            // block timestamp: 1640782880 ~= 05:01:20; ~50% collateral is offered
+            await fork(13900364);
+            const [_owner, liquidator] = await deploy_flash_liquidator();
+
+            const liquidator_logs = await run_liquidator(tmp_root, liquidator);
+
+            let new_vaults_message;
+            for (const log_record of liquidator_logs) {
+                if (log_record["level"] == "INFO" && log_record["fields"]["message"] == "Submitted buy order") {
+                    const vault_id = log_record["fields"]["vault_id"];
+                    expect(vault_id).to.not.equal(`"${test_vault_id}"`);
+                }
+                if (log_record["fields"]["message"] && log_record["fields"]["message"].startsWith("New vaults: ")) {
+                    new_vaults_message = log_record["fields"]["message"];
+                }
+
+            }
+            // to make sure the bot did something and did not just crash
+            expect(new_vaults_message).to.be.equal("New vaults: 1073");
+        })
+    });
 });

--- a/src/bin/liquidator.rs
+++ b/src/bin/liquidator.rs
@@ -45,6 +45,9 @@ struct Opts {
     #[options(help = "Don't bump gas until the transaction is this many seconds old", default = "90")]
     bump_gas_delay: u64,
 
+    #[options(help = "Buy an auction as soon as this much collateral percentage is offered", default = "90")]
+    target_collateral_offer: u16,
+
     #[options(help = "the block to start watching from")]
     start_block: Option<u64>,
 
@@ -162,6 +165,7 @@ async fn run<P: JsonRpcClient + 'static>(opts: Opts, provider: Provider<P>) -> a
         opts.gas_boost,
         gas_escalator,
         opts.bump_gas_delay,
+        opts.target_collateral_offer,
         state,
         format!("{}.witch={:?}.flash={:?}", opts.instance_name, cfg.witch, cfg.flashloan)
     ).await?;

--- a/src/keeper.rs
+++ b/src/keeper.rs
@@ -53,6 +53,7 @@ impl<M: Middleware> Keeper<M> {
         gas_boost: u16,
         gas_escalator: GeometricGasPrice,
         bump_gas_delay: u64,
+        target_collateral_offer: u16,
         state: Option<State>,
         instance_name: String,
     ) -> Result<Keeper<M>, M> {
@@ -79,6 +80,7 @@ impl<M: Middleware> Keeper<M> {
             Some(multicall2),
             min_ratio,
             gas_boost,
+            target_collateral_offer,
             client.clone(),
             auctions,
             gas_escalator,


### PR DESCRIPTION
Instead of waiting until 100% of collateral is offered, we liquidate when %target_collateral_offer
is offered (default=90). This makes the bot a bit user-friendlier