### PR TITLE
Tweak: don't try to liquidate trivial vaults

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@yield-protocol/yield-liquidator-v2",
   "description": "Yield Flash Liquidator",
-  "version": "0.0.5-rc3",
+  "version": "0.0.5-rc4",
   "engines": {
     "node": ">=12"
   },


### PR DESCRIPTION
The liquidation won't succeed anyways, so we save a bit of time by not trying

Also, publishing v0.0.5-rc4